### PR TITLE
Fix image tagging in CI

### DIFF
--- a/.github/workflows/publish-and-release.yml
+++ b/.github/workflows/publish-and-release.yml
@@ -95,7 +95,7 @@ jobs:
 
   merge_to_release:
     name: Merge to Release
-    needs: push_to_registry
+    needs: [ push_to_registry, get_version ]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
@@ -118,6 +118,8 @@ jobs:
       - name: Apply Newest Version
         shell: bash
         run: |
+          echo "Image tag being patched to manifests:"
+          echo ${{ needs.get_version.outputs.SemVer }}
           yq -i '.version = "${{ needs.get_version.outputs.SemVer }}"' ./deployment/route96/Chart.yaml
           yq -i '.appVersion = "${{ needs.get_version.outputs.SemVer }}"' ./deployment/route96/Chart.yaml
           yq -i '.image.tag = "${{ needs.get_version.outputs.SemVer }}"' ./deployment/route96/values.yaml


### PR DESCRIPTION
This should be a quick fix to the way CI patches the image version in the kubernetes manifests, to fix the empty string that was showing up there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow dependencies for improved process clarity.
  - Added version logging during deployment to enhance transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->